### PR TITLE
Add null-ls formatter plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains my personal Neovim configuration files.
 
+## Code Formatting
+
+Install formatters via Mason and press `<leader>cf` to format the current buffer. This uses `null-ls.nvim` with Prettier, Stylua, isort and Black.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/lua/contragamer/plugins/format.lua
+++ b/lua/contragamer/plugins/format.lua
@@ -1,0 +1,25 @@
+return {
+  "jose-elias-alvarez/null-ls.nvim",
+  dependencies = { "nvim-lua/plenary.nvim" },
+  config = function()
+    local safe_require = require("contragamer.utils").safe_require
+    local null_ls = safe_require("null-ls")
+    if not null_ls then
+      return
+    end
+
+    null_ls.setup({
+      sources = {
+        null_ls.builtins.formatting.prettier,
+        null_ls.builtins.formatting.stylua,
+        null_ls.builtins.formatting.isort,
+        null_ls.builtins.formatting.black,
+      },
+    })
+
+    local keymap = vim.keymap
+    keymap.set("n", "<leader>cf", function()
+      vim.lsp.buf.format()
+    end, { desc = "Format current file" })
+  end,
+}


### PR DESCRIPTION
## Summary
- add a new formatting plugin using `null-ls.nvim`
- document how to format code with `<leader>cf`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841b3d1c62c832fbc31514372f0b082